### PR TITLE
Feature/issues#67

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -19,6 +19,16 @@ class AgendasController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    @article = Article.where(agenda_id: @agenda.id)
+    @article.each do |article|
+      article.destroy
+    end
+
+    @agenda.destroy
+    redirect_to dashboard_url, notice: "アジェンダが削除されました！"
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -19,6 +19,11 @@ class AgendasController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    redirect_to dashboard_url, notice: 'アジェンダが削除されました！'
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -23,6 +23,7 @@ class AgendasController < ApplicationController
 
   def destroy
     @agenda.destroy
+    AgendaMailer.agenda_mail(@agenda).deliver
     redirect_to dashboard_url, notice: 'アジェンダが削除されました！'
   end
 

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,7 @@
+class AgendaMailer < ApplicationMailer
+  def agenda_mail(agenda)
+    @agenda = agenda
+    @email = @agenda.team.users
+    mail to: @email, subject: "アジェンダの削除のお知らせ"
+  end
+end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,3 @@
+<h4>アジェンダ削除のお知らせメール</h4>
+<p>Team名: <%= @agenda.team.name %></p>
+<p>Agenda名: <%= @agenda.title %></p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,6 +34,11 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                <% if (current_user.id == agenda.user.id) || (current_user.id == agenda.team.owner.id) %>
+                  <span>
+                    <object><%= link_to '削除', agenda_path(agenda), method: :delete, class:'btn btn-danger' %></object>
+                  </span>
+                <% end %>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -38,6 +38,7 @@
                 <% if (current_user.id == agenda.user.id) || (current_user.id == agenda.team.owner.id) %>
                   <span>
                     <object><%= link_to '削除', agenda_path(agenda), method: :delete, class:'btn btn-danger' %></object>
+                    <%# binding.irb %>
                   </span>
                 <% end %>
               </p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,11 +34,6 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
-                <% if (current_user.id == agenda.user.id) || (current_user.id == agenda.team.owner.id) %>
-                  <span>
-                    <object><%= link_to '削除', agenda_path(agenda), method: :delete, class:'btn btn-danger' %></object>
-                  </span>
-                <% end %>
                 <i class="right fa fa-angle-left"></i>
                 <% if (current_user.id == agenda.user.id) || (current_user.id == agenda.team.owner.id) %>
                   <span>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -35,6 +35,11 @@
               <p>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
+                <% if (current_user.id == agenda.user.id) || (current_user.id == agenda.team.owner.id) %>
+                  <span>
+                    <object><%= link_to '削除', agenda_path(agenda), method: :delete, class:'btn btn-danger' %></object>
+                  </span>
+                <% end %>
               </p>
             </a>
             <ul class="nav nav-treeview" style="display: block;">

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
- gendasControllerのdestroyアクションを追加し、そこに機能追加する
- Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- Agendaに紐づいているarticleも一緒に削除される
- Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
- 情報処理が完了した後はDashBoardに飛ぶ
- その他、アプリケーションの挙動に不審な点やエラーがないこと